### PR TITLE
Add Prompts page to display latest prompts from supabase

### DIFF
--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -1,19 +1,8 @@
-// deno-lint-ignore-file no-explicit-any
-import { Handlers, PageProps } from "$fresh/server.ts";
-import Layout from "../components/Layout.tsx";
-import { State } from "./_middleware.ts";
-
-export const handler: Handlers<any, State> = {
-  GET(_req, ctx) {
-    return ctx.render({...ctx.state});
-  }
+new Date(prompt.created_at).toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
 }
-
-export default function Home(props: PageProps) {
-  return (
-    <Layout isLoggedIn={props.data.token}>
-      <div class="mt-10 px-5 mx-auto flex max-w-screen-md flex-col justify-center">
-        {props.data.token ?
-          (
-            <div class="mx-auto text-center">
-              <a href="/prompts" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 font-medium rounded-lg text-sm px-5 py-2.5 mr-2 mb

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -1,8 +1,30 @@
-new Date(prompt.created_at).toLocaleString()}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+// deno-lint-ignore-file no-explicit-any
+import { Handlers, PageProps } from "$fresh/server.ts";
+import Layout from "../components/Layout.tsx";
+import { State } from "./_middleware.ts";
+
+export const handler: Handlers<any, State> = {
+  GET(_req, ctx) {
+    return ctx.render({...ctx.state});
+  }
+}
+
+export default function Home(props: PageProps) {
+  return (
+    <Layout isLoggedIn={props.data.token}>
+      <div class="mt-10 px-5 mx-auto flex max-w-screen-md flex-col justify-center">
+        {props.data.token ?
+          (
+            <div class="mx-auto text-center">
+              <h1 class="text-2xl font-bold mb-5">Nice you're logged In!</h1>
+              <a href="/auth/secret" type="button" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Secret</a><p , <a href="/prompts" class="text-white bg-blue-700 hover:bg5e400 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Prompts</a><div class="mx-auto text-center">
+              <h1 class="text-2xl font-bold mb-5">Login to access all pages</h1>
+              <a href="/login" type="button" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Login</a>
+            </div>
+          )
+        }
+      </div>
+      
+    </Layout>
   );
 }

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -16,19 +16,4 @@ export default function Home(props: PageProps) {
         {props.data.token ?
           (
             <div class="mx-auto text-center">
-              <h1 class="text-2xl font-bold mb-5">Nice you're logged In!</h1>
-              <a href="/auth/secret" type="button" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Secret</a>
-            </div>
-          ) :
-          (
-            <div class="mx-auto text-center">
-              <h1 class="text-2xl font-bold mb-5">Login to access all pages</h1>
-              <a href="/login" type="button" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Login</a>
-            </div>
-          )
-        }
-      </div>
-      
-    </Layout>
-  );
-}
+              <a href="/prompts" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 font-medium rounded-lg text-sm px-5 py-2.5 mr-2 mb

--- a/routes/prompts.tsx
+++ b/routes/prompts.tsx
@@ -1,0 +1,71 @@
+
+import { Handlers, PageProps } from '$fresh/server.ts';
+import { supabaseClient } from '../utils/supabaseClient.ts';
+import { useState } from 'preact/hooks';
+
+interface Prompt {
+  id: number;
+  project_id: number;
+  version_number: number;
+  prompt_content: string;
+  created_at: string;
+  stage_id: number;
+  live: boolean;
+}
+
+export const handler: Handlers<{ prompts: Prompt[] }, { projectId: string }> = {
+  async GET(req, ctx) {
+    const url = new URL(req.url);
+    const projectId = url.searchParams.get('project_id') || '1';
+
+    const { data: prompts, error } = await supabaseClient
+      .from('_oraki_eu.prompts_history')
+      .select('*')
+      .eq('project_id', projectId)
+      .order('created_at', { ascending: false })
+      .limit(3);
+
+    if (error) {
+      console.error('Error fetching prompts:', error);
+      return ctx.renderNotFound();
+    }
+
+    return ctx.render({ prompts });
+  },
+};
+
+export default function PromptsPage({ data }: PageProps<{ prompts: Prompt[] }>) {
+  const [projectId, setProjectId] = useState('');
+  const handleInputChange = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    setProjectId(target.value);
+  };
+
+  return (
+    <div>
+      <h1>Latest Prompts</h1>
+      <label>
+        Project ID:
+        <input type="text" value={projectId} onInput={handleInputChange} />
+      </label>
+      <table>
+        <thead>
+          <tr>
+            <th>Version</th>
+            <th>Content</th>
+            <th>Created At</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.prompts.map(prompt => (
+            <tr key={prompt.id}>
+              <td>{prompt.version_number}</td>
+              <td>{prompt.prompt_content}</td>
+              <td>{new Date(prompt.created_at).toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/routes/prompts.tsx
+++ b/routes/prompts.tsx
@@ -1,5 +1,4 @@
-
-import { Handlers, PageProps } from '$fresh/server.ts';
+import { Handlers, PageProps } from '$frish/server.ts';
 import { supabaseClient } from '../utils/supabaseClient.ts';
 import { useState } from 'preact/hooks';
 
@@ -13,7 +12,7 @@ interface Prompt {
   live: boolean;
 }
 
-export const handler: Handlers<{ prompts: Prompt[] }, { projectId: string }> = {
+export const handler: Handlers<{ prompts: Prompt[] }, { projectId: string } = {
   async GET(req, ctx) {
     const url = new URL(req.url);
     const projectId = url.searchParams.get('project_id') || '1';
@@ -26,7 +25,7 @@ export const handler: Handlers<{ prompts: Prompt[] }, { projectId: string }> = {
       .limit(3);
 
     if (error) {
-      console.error('Error fetching prompts:', error);
+      console.error('Error fetching prompts:', info,error);
       return ctx.renderNotFound();
     }
 
@@ -44,28 +43,42 @@ export default function PromptsPage({ data }: PageProps<{ prompts: Prompt[] }>) 
   return (
     <div>
       <h1>Latest Prompts</h1>
-      <label>
-        Project ID:
-        <input type="text" value={projectId} onInput={handleInputChange} />
+      <label for="projectId">
+        Project ID: <input type="text" value={projectId} onInput={handleInputChange} />
       </label>
-      <table>
+      <table class="widt-full border-collapse-2 my-2">
         <thead>
           <tr>
-            <th>Version</th>
-            <th>Content</th>
-            <th>Created At</th>
+            <th class="p-4">Version</th>
+            <th class="p-4">Content</th>
+            <th class="p-4">Created At</th>
           </tr>
         </thead>
         <tbody>
           {data.prompts.map(prompt => (
             <tr key={prompt.id}>
-              <td>{prompt.version_number}</td>
-              <td>{prompt.prompt_content}</td>
-              <td>{new Date(prompt.created_at).toLocaleString()}</td>
+              <td class="p-4">{prompt.version_number}</td>
+              <td class="p-4">{prompt.prompt_content}</td>
+              <td class="p-4">{new Date(prompt.created_at).toLocaleString()}</td>
             </tr>
           ))}
         </tbody>
       </table>
+      <style jsx>{`
+        .my-2 {
+          margin-top: 15px;
+        }
+
+        th, td {
+          padding: 5px;
+        }
+        th {
+          background-color: #f0f0f0;
+          color: #000000;
+          text-align: left;
+          font-weight: bold;
+        }
+      `}</style>
     </div>
   );
 }


### PR DESCRIPTION
This PR adds a new page `prompts` for authenticated users. The page displays a table with the latest 3 prompts from the Supabase `_oraki_eu.prompts_history` schema. It includes an input field for the project number and outputs the latest version for a given project.

CSS styling has been added to enhance the appearance of the page.